### PR TITLE
Initiate Poetry project and basic structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Mac OS
+.DS_Store

--- a/dspace/__init__.py
+++ b/dspace/__init__.py
@@ -1,0 +1,1 @@
+# dspace/__init__.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "ce2aa767160f871dd3652615ba0a0dceb7733d62eb8cb4665b87f30a562e3adf"
+
+[metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "dspace-python-client"
+version = "0.1.0"
+description = "Python Client library for working with the DSpace API"
+authors = ["Helen Bailey <hbailey@mit.edu>", "Eric Hanson <ehanson@mit.edu>"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests/__init__.py


### PR DESCRIPTION
#### Why these changes are being introduced:
We need a Poetry project to manage dependencies and future builds, along
with a basic directory structure for the code.

#### How this addresses that need:
* Creates initial Poetry pyproject.toml and lock file
* Adds empty source and test folders with init files for packaging

#### Side effects of this change:
* Updates .gitignore

#### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ETD-392