### PR TITLE
Make DSpaceClient request timeout configurable

### DIFF
--- a/dspace/client.py
+++ b/dspace/client.py
@@ -18,26 +18,39 @@ class DSpaceClient:
         base_url: The base url of the DSpace API
         accept_header: The response type to use in the requests "accept" header -- one
             of "application/json" or "application/xml", defaults to "application/json"
+        timeout: The `timeout`_, in seconds, to use for all requests sent to the DSpace
+            API, defaults to 3.0
 
     Attributes:
         base_url: The base url of the DSpace API
         cookies: Cookies for use in client requests
         headers: Headers for use in client requests
+        timeout: Timeout value for use in client requests
+
+    .. _timeout: https://docs.python-requests.org/en/latest/user/quickstart/#timeouts
     """
 
-    def __init__(self, base_url: str, accept_header: str = "application/json"):
+    def __init__(
+        self,
+        base_url: str,
+        accept_header: str = "application/json",
+        timeout: float = 3.0,
+    ):
         self.base_url: str = base_url.rstrip("/")
         self.headers: Dict[str, str] = {"accept": accept_header}
+        self.timeout: float = timeout
         self.cookies: dict = {}
         logger.debug(
             f"Client initialized with params base_url={self.base_url}, "
-            f"accept_header={self.headers}"
+            f"accept_header={self.headers}, "
+            f"timeout={self.timeout}"
         )
 
     def __repr__(self):
         return (
             f"DSpaceClient(base_url='{self.base_url}', "
-            f"accept_header='{self.headers['accept']}')"
+            f"accept_header='{self.headers['accept']}', "
+            f"timeout={self.timeout})"
         )
 
     def delete(self, endpoint: str) -> requests.Response:
@@ -57,12 +70,12 @@ class DSpaceClient:
         Raises:
             :class:`requests.exceptions.HTTPError`: if response status code is 4xx or
                 5xx
-            :class:`requests.exceptions.Timeout`: if server takes more than 5 seconds to
-                respond
+            :class:`requests.exceptions.Timeout`: if server takes longer than the
+                client's timeout value to respond
         """
         url = self.base_url + endpoint
         response = requests.delete(
-            url, cookies=self.cookies, headers=self.headers, timeout=15.0
+            url, cookies=self.cookies, headers=self.headers, timeout=self.timeout
         )
         response.raise_for_status()
         return response
@@ -84,12 +97,16 @@ class DSpaceClient:
         Raises:
             :class:`requests.exceptions.HTTPError`: if response status code is 4xx or
                 5xx
-            :class:`requests.exceptions.Timeout`: if server takes more than 5 seconds to
-                respond
+            :class:`requests.exceptions.Timeout`: if server takes longer than the
+                client's timeout value to respond
         """
         url = self.base_url + endpoint
         response = requests.get(
-            url, cookies=self.cookies, headers=self.headers, params=params, timeout=5.0
+            url,
+            cookies=self.cookies,
+            headers=self.headers,
+            params=params,
+            timeout=self.timeout,
         )
         response.raise_for_status()
         return response
@@ -161,8 +178,8 @@ class DSpaceClient:
         Raises:
             :class:`requests.exceptions.HTTPError`: if response status code is 4xx or
                 5xx
-            :class:`requests.exceptions.Timeout`: if server takes more than 15 seconds
-                to respond
+            :class:`requests.exceptions.Timeout`: if server takes longer than the
+                client's timeout value to respond
         """
         url = self.base_url + endpoint
         response = requests.post(
@@ -172,7 +189,7 @@ class DSpaceClient:
             headers=self.headers,
             json=json,
             params=params,
-            timeout=15.0,
+            timeout=self.timeout,
         )
         response.raise_for_status()
         return response

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,13 +10,15 @@ def test_client_instantiates_with_expected_values():
     client = DSpaceClient("https://dspace-example.com/rest")
     assert client.headers["accept"] == "application/json"
     assert client.base_url == "https://dspace-example.com/rest"
+    assert client.timeout == 3.0
 
 
 def test_client_repr():
     client = DSpaceClient("https://dspace-example.com/rest")
     assert str(client) == (
         "DSpaceClient(base_url='https://dspace-example.com/rest', "
-        "accept_header='application/json')"
+        "accept_header='application/json', "
+        "timeout=3.0)"
     )
 
 


### PR DESCRIPTION
#### What does this PR do?
* Adds timeout as an instance parameter to the DSpaceClient class with a default value of 3.0.
* Passes the DSpaceClient instance's timeout value as the request timeout in each of the client's currently implemented base API request methods: delete, get, and post.

#### Helpful background context
Different DSpace instances may be faster or slower to respond to API requests depending on a number of variables around each instance's configuration, which means that the timeout value for a DSpace API client should also be configurable to match the needs of a given DSpace instance.

#### How can a reviewer manually see the effects of these changes?
While connected to the VPN, create and test a DSpaceClient instance as follows:
```
poetry run python
from dspace.client import DSpaceClient
client = DSpaceClient(<DSpace test API base url>)
client.status() # Confirm API call works with default timeout of 3 seconds
client.timeout = 0.00001 # Set timeout to something unreasonably short
client.status() # This should give a requests timeout error
```

#### Includes new or updated dependencies?
NO

#### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ETD-474

#### Developer
- [x] Docstrings and README are updated to reflect all changes as needed
- [x] Sphinx source docs are updated to reflect all changes as needed
- [x] All related Jira tickets are linked in commit message(s)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated to reflect all changes or is not needed
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes
